### PR TITLE
Add simple training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# tst
+# AI Training Example
+
+This repository contains a small script for training a machine learning model on a CSV dataset.
+
+## Usage
+
+Install dependencies (requires Python 3.11):
+
+```bash
+pip install pandas scikit-learn joblib
+```
+
+Train a model by providing a CSV file and target column name:
+
+```bash
+python train_model.py path/to/data.csv --target label
+```
+
+The script splits the data into train/test sets, trains a random forest classifier, prints the test accuracy, and saves the model to `model.joblib` by default.

--- a/train_model.py
+++ b/train_model.py
@@ -1,0 +1,35 @@
+import argparse
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import accuracy_score
+import joblib
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train a simple classifier.")
+    parser.add_argument("csv", help="Path to CSV dataset")
+    parser.add_argument("--target", required=True, help="Name of target column")
+    parser.add_argument("--model-out", default="model.joblib", help="Path to save trained model")
+    parser.add_argument("--test-size", type=float, default=0.2, help="Fraction of data for testing")
+    args = parser.parse_args()
+
+    data = pd.read_csv(args.csv)
+    X = data.drop(columns=[args.target])
+    y = data[args.target]
+
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=args.test_size, random_state=42)
+
+    clf = RandomForestClassifier(random_state=42)
+    clf.fit(X_train, y_train)
+
+    preds = clf.predict(X_test)
+    acc = accuracy_score(y_test, preds)
+    print(f"Test accuracy: {acc:.3f}")
+
+    joblib.dump(clf, args.model_out)
+    print(f"Model saved to {args.model_out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `train_model.py` for training a random forest on CSV data
- update README with usage instructions

## Testing
- `python train_model.py --help`
- `python train_model.py iris.csv --target label --model-out iris_model.joblib`

------
https://chatgpt.com/codex/tasks/task_e_6858c77908d8832da8ed29ff02457538