### PR TITLE
Add curses-based BTC monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,14 @@ Run it after installing the requirements:
 pip install -r requirements.txt
 python wyckoff_live.py
 ```
+
+## Interactive Monitor
+
+`monitor_ui.py` displays a simple text-based interface showing the current BTC price and whether the heuristic Wyckoff accumulation detector is triggered. It updates automatically every minute.
+
+Run it with:
+
+```bash
+pip install -r requirements.txt
+python monitor_ui.py
+```

--- a/monitor_ui.py
+++ b/monitor_ui.py
@@ -1,0 +1,40 @@
+import curses
+import time
+
+from btc_price import fetch_coinbase
+from wyckoff.data import fetch_klines
+from wyckoff.features import compute_features
+from wyckoff_live import detect_wyckoff
+
+
+def draw_screen(stdscr: curses.window) -> None:
+    curses.curs_set(0)
+    stdscr.nodelay(True)
+    while True:
+        stdscr.erase()
+        try:
+            price = fetch_coinbase()
+            df = fetch_klines(limit=200)
+            feat = compute_features(df)
+            wyckoff = detect_wyckoff(feat)
+            stdscr.addstr(0, 0, "BTC Live Monitor", curses.A_BOLD)
+            stdscr.addstr(2, 0, f"Price: ${price:.2f}")
+            status = "DETECTED" if wyckoff else "None"
+            stdscr.addstr(3, 0, f"Wyckoff accumulation: {status}")
+        except Exception as exc:
+            stdscr.addstr(5, 0, f"Error: {exc}")
+        stdscr.addstr(7, 0, "Press 'q' to quit. Updates every minute.")
+        stdscr.refresh()
+        for _ in range(60):
+            ch = stdscr.getch()
+            if ch == ord('q'):
+                return
+            time.sleep(1)
+
+
+def main() -> None:
+    curses.wrapper(draw_screen)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `monitor_ui.py` script with a curses interface to monitor BTC price and Wyckoff detection
- document how to run the interactive monitor in README

## Testing
- `python -m compileall -q .`
- `python -m py_compile monitor_ui.py`
- `pip install -r requirements.txt` *(passed)*

------
https://chatgpt.com/codex/tasks/task_e_6858d48d7b68832daec57fb87570b21f