### PR TITLE
Improve Windows support for curses UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,10 @@ Run it with:
 
 ```bash
 pip install -r requirements.txt
+# Windows users also need the optional curses package
+pip install windows-curses
 python monitor_ui.py
 ```
+
+On Linux and macOS the built-in `curses` module is used automatically, but
+on Windows the `windows-curses` package must be installed separately.

--- a/monitor_ui.py
+++ b/monitor_ui.py
@@ -1,4 +1,12 @@
-import curses
+import os
+try:
+    import curses
+except ModuleNotFoundError as exc:
+    if os.name == "nt":
+        raise ModuleNotFoundError(
+            "curses is required. Install it with 'pip install windows-curses' on Windows"
+        ) from exc
+    raise
 import time
 
 from btc_price import fetch_coinbase


### PR DESCRIPTION
## Summary
- provide helpful error message if curses is missing on Windows
- document that Windows users must install `windows-curses` for the monitor UI

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6858d732e114832db00905f974e4719b