### PR TITLE
Improve wyckoff monitor output

### DIFF
--- a/monitor_ui.py
+++ b/monitor_ui.py
@@ -18,20 +18,30 @@ from wyckoff_live import detect_wyckoff
 def draw_screen(stdscr: curses.window) -> None:
     curses.curs_set(0)
     stdscr.nodelay(True)
+    last_time = None
+    last_detected = False
+    last_reasons: list[str] = []
     while True:
         stdscr.erase()
         try:
             price = fetch_coinbase()
-            df = fetch_klines(limit=200)
+            df = fetch_klines(interval="1m", limit=200)
             feat = compute_features(df)
-            wyckoff = detect_wyckoff(feat)
+            latest_time = feat.iloc[-1]["open_time"]
+            if latest_time != last_time:
+                last_detected, last_reasons = detect_wyckoff(feat)
+                last_time = latest_time
+
             stdscr.addstr(0, 0, "BTC Live Monitor", curses.A_BOLD)
             stdscr.addstr(2, 0, f"Price: ${price:.2f}")
-            status = "DETECTED" if wyckoff else "None"
+            status = "DETECTED" if last_detected else "None"
             stdscr.addstr(3, 0, f"Wyckoff accumulation: {status}")
+            if last_detected:
+                stdscr.addstr(4, 0, ", ".join(last_reasons))
+            stdscr.addstr(5, 0, f"Last close: {latest_time}")
         except Exception as exc:
-            stdscr.addstr(5, 0, f"Error: {exc}")
-        stdscr.addstr(7, 0, "Press 'q' to quit. Updates every minute.")
+            stdscr.addstr(7, 0, f"Error: {exc}")
+        stdscr.addstr(9, 0, "Press 'q' to quit. Updates every minute.")
         stdscr.refresh()
         for _ in range(60):
             ch = stdscr.getch()

--- a/wyckoff_live.py
+++ b/wyckoff_live.py
@@ -6,30 +6,48 @@ from wyckoff.data import fetch_klines
 from wyckoff.features import compute_features
 
 
-def detect_wyckoff(df: pd.DataFrame) -> bool:
-    """Simple heuristic to detect possible Wyckoff accumulation phase."""
+def detect_wyckoff(df: pd.DataFrame) -> tuple[bool, list[str]]:
+    """Return whether Wyckoff conditions are met and the reasons."""
     df = df.copy()
     df["sma_50"] = df["close"].rolling(50).mean()
     latest = df.iloc[-1]
+
+    reasons = []
     cond_price_above_sma = latest["close"] > latest["sma_50"]
+    if cond_price_above_sma:
+        reasons.append("price above SMA50")
     cond_rsi = latest["rsi"] > 50
+    if cond_rsi:
+        reasons.append("RSI > 50")
     cond_macd = latest["macd_diff"] > 0
-    return cond_price_above_sma and cond_rsi and cond_macd
+    if cond_macd:
+        reasons.append("MACD diff > 0")
+
+    is_detected = cond_price_above_sma and cond_rsi and cond_macd
+    return is_detected, reasons
 
 
 def main() -> None:
+    last_time = None
     while True:
         try:
             price = fetch_coinbase()
-            df = fetch_klines(limit=200)
+            df = fetch_klines(interval="1m", limit=200)
             feat = compute_features(df)
-            if detect_wyckoff(feat):
-                print(f"BTC price ${price:.2f} - Possible Wyckoff accumulation detected")
-            else:
-                print(f"BTC price: ${price:.2f}")
+            latest_time = feat.iloc[-1]["open_time"]
+            if latest_time != last_time:
+                detected, reasons = detect_wyckoff(feat)
+                if detected:
+                    reason_str = ", ".join(reasons)
+                    print(
+                        f"{latest_time} - BTC price ${price:.2f} - Possible Wyckoff accumulation detected ({reason_str})"
+                    )
+                else:
+                    print(f"{latest_time} - BTC price: ${price:.2f}")
+                last_time = latest_time
         except Exception as exc:
             print(f"Error: {exc}")
-        time.sleep(300)
+        time.sleep(60)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- adjust wyckoff_live monitor to check 1m candles and print once per new close
- show reasons why the Wyckoff heuristic was triggered
- update curses UI to display the same info

## Testing
- `python -m py_compile wyckoff_live.py monitor_ui.py`
- `python wyckoff_live.py` *(fails: 451 Client Error)*

------
https://chatgpt.com/codex/tasks/task_e_6858d9787524832dae4a6add44fe74d6