### PR TITLE
Add live candlestick chart monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,16 @@ python monitor_ui.py
 
 On Linux and macOS the built-in `curses` module is used automatically, but
 on Windows the `windows-curses` package must be installed separately.
+
+## Candlestick Window
+
+`candlestick_monitor.py` opens a small window displaying a live candlestick
+chart for the last 30 minutes of BTC/USDT data. The chart updates at a
+configurable interval (default 10 seconds).
+
+Run it with:
+
+```bash
+pip install -r requirements.txt
+python candlestick_monitor.py
+```

--- a/candlestick_monitor.py
+++ b/candlestick_monitor.py
@@ -1,0 +1,39 @@
+import argparse
+import matplotlib.pyplot as plt
+import mplfinance as mpf
+
+from wyckoff.data import fetch_klines
+
+
+def fetch_last_30min() -> None:
+    """Return last 30 minutes of 1m OHLC data."""
+    df = fetch_klines(interval="1m", limit=30)
+    df.set_index("open_time", inplace=True)
+    return df
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Live 30 minute candlestick chart")
+    parser.add_argument("--interval", default=10, type=int, help="Refresh interval seconds")
+    args = parser.parse_args()
+
+    plt.style.use("seaborn-v0_8")
+    fig, ax = plt.subplots()
+
+    while True:
+        try:
+            df = fetch_last_30min()
+        except Exception as exc:
+            ax.clear()
+            ax.text(0.5, 0.5, f"Error:\n{exc}", ha="center", va="center")
+            plt.pause(args.interval)
+            continue
+
+        ax.clear()
+        mpf.plot(df, type="candle", ax=ax, style="charles")
+        ax.set_title("BTC/USDT last 30 minutes")
+        plt.pause(args.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ scikit-learn
 requests
 ta
 joblib
+matplotlib
+mplfinance


### PR DESCRIPTION
## Summary
- show live 30-minute candlestick chart in `candlestick_monitor.py`
- require `matplotlib` and `mplfinance`
- document candlestick monitor usage

## Testing
- `python -m py_compile btc_price.py monitor_ui.py wyckoff_live.py candlestick_monitor.py wyckoff/*.py`
- `python candlestick_monitor.py --interval 1` *(fails: 451 Client Error from api.binance.com)*

------
https://chatgpt.com/codex/tasks/task_e_6858db850c34832da69cd81778664bfb