### PR TITLE
Add incremental candlestick viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,14 @@ Run it with:
 pip install -r requirements.txt
 python candlestick_monitor.py
 ```
+
+## Live Candlestick Chart
+
+`live_candles.py` shows an incremental candlestick chart built from 1 minute BTC/USDT candles. Only new candles are fetched and appended to the chart at the given refresh interval.
+
+Run it with:
+
+```bash
+pip install -r requirements.txt
+python live_candles.py
+```

--- a/live_candles.py
+++ b/live_candles.py
@@ -1,0 +1,52 @@
+import argparse
+import pandas as pd
+import matplotlib.pyplot as plt
+import mplfinance as mpf
+
+from wyckoff.data import fetch_klines
+
+
+def fetch_initial(minutes: int) -> pd.DataFrame:
+    """Return initial dataframe of given minutes."""
+    df = fetch_klines(interval="1m", limit=minutes)
+    df.set_index("open_time", inplace=True)
+    return df
+
+
+def update_df(df: pd.DataFrame, max_len: int) -> pd.DataFrame:
+    """Fetch latest closed candle and append if new."""
+    latest = fetch_klines(interval="1m", limit=2)
+    latest.set_index("open_time", inplace=True)
+    closed = latest.iloc[-2:-1]
+    if closed.index[0] not in df.index:
+        df = pd.concat([df, closed])
+        df = df.tail(max_len)
+    return df
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Live BTC candlestick chart")
+    parser.add_argument("--minutes", type=int, default=60, help="Displayed history length")
+    parser.add_argument("--interval", type=int, default=60, help="Refresh interval in seconds")
+    args = parser.parse_args()
+
+    plt.style.use("seaborn-v0_8")
+    fig, ax = plt.subplots()
+
+    df = fetch_initial(args.minutes)
+
+    while True:
+        try:
+            df = update_df(df, args.minutes)
+            ax.clear()
+            mpf.plot(df, type="candle", ax=ax, style="charles")
+            ax.set_title("BTC/USDT live")
+            plt.pause(args.interval)
+        except Exception as exc:
+            ax.clear()
+            ax.text(0.5, 0.5, f"Error:\n{exc}", ha="center", va="center")
+            plt.pause(args.interval)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `live_candles.py` that continuously fetches new BTC/USDT candles and updates the chart
- document the new script in the README

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `timeout 5 python live_candles.py --minutes 2 --interval 1` *(fails: 451 Client Error)*

------
https://chatgpt.com/codex/tasks/task_e_6858dd982d74832daa6edfb99c6931d6